### PR TITLE
Make more CPU efficient

### DIFF
--- a/Polyhedra.xcodeproj/project.pbxproj
+++ b/Polyhedra.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		151E30D72765217C00F50B2D /* PolyhedronView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151E30D62765217C00F50B2D /* PolyhedronView.swift */; };
 		FA56FE7725DDE54600CCD1A5 /* colors.json in Resources */ = {isa = PBXBuildFile; fileRef = FA56FE7625DDE54600CCD1A5 /* colors.json */; };
 		FA8AD16525A3C07A0067F17B /* polyhedra.json in Resources */ = {isa = PBXBuildFile; fileRef = FA8AD16425A3C07A0067F17B /* polyhedra.json */; };
 		FACBCF7D259F77AE0039CF3E /* PolyhedraScreenSaverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBCF7C259F77AE0039CF3E /* PolyhedraScreenSaverView.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		151E30D62765217C00F50B2D /* PolyhedronView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolyhedronView.swift; sourceTree = "<group>"; };
 		FA56FE7625DDE54600CCD1A5 /* colors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = colors.json; sourceTree = "<group>"; };
 		FA8AD16425A3C07A0067F17B /* polyhedra.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = polyhedra.json; sourceTree = "<group>"; };
 		FACBCF6C259F777F0039CF3E /* Polyhedra.saver */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Polyhedra.saver; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -69,6 +71,7 @@
 				FACBCF91259FF4810039CF3E /* PolyhedraSettings.swift */,
 				FA8AD16425A3C07A0067F17B /* polyhedra.json */,
 				FA56FE7625DDE54600CCD1A5 /* colors.json */,
+				151E30D62765217C00F50B2D /* PolyhedronView.swift */,
 			);
 			path = Polyhedra;
 			sourceTree = "<group>";
@@ -203,6 +206,7 @@
 				FACBCF8F259F91690039CF3E /* ConfigSheetController.swift in Sources */,
 				FACBCF92259FF4810039CF3E /* PolyhedraSettings.swift in Sources */,
 				FACBCF82259F81630039CF3E /* Polyhedra.swift in Sources */,
+				151E30D72765217C00F50B2D /* PolyhedronView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Polyhedra/PolyhedraScreenSaverView.swift
+++ b/Polyhedra/PolyhedraScreenSaverView.swift
@@ -6,20 +6,15 @@ class PolyhedraScreenSaverView: ScreenSaverView {
     private var radius: CGFloat = .zero
     private var maxX: CGFloat = .zero
     private var maxY: CGFloat = .zero
-    private var rotation: Int = .zero
     private lazy var sheetController = ConfigSheetController()
-    private var cachedRenderings: [CachedRendering] = []
     private var settings = PolyhedraSettings()
-    private var textRect: NSRect = .zero
-    private var textAttributes: [NSAttributedString.Key: Any] = .init()
+    private var polyhedronView: PolyhedronView?
 
     override init?(frame: NSRect, isPreview: Bool) {
         super.init(frame: frame, isPreview: isPreview)
-        var fontSize: CGFloat = 24
         if isPreview {
             radius = 25
             velocity = CGVector(dx: 5, dy: 5)
-            fontSize = 5
         } else {
             radius = 150
             velocity = CGVector(dx: 10, dy: 10)
@@ -30,20 +25,29 @@ class PolyhedraScreenSaverView: ScreenSaverView {
         // place at a random point in the frame
         position.x = CGFloat.random(in: 0 ..< maxX)
         position.y = CGFloat.random(in: 0 ..< maxY)
-        // configure text
-        let font = NSFont.systemFont(ofSize: fontSize)
-        textRect = NSRect(x: fontSize, y: fontSize, width: frame.width, height: fontSize * 1.5)
-        let color = NSColor(calibratedWhite: 1.0, alpha: 0.2)
-        textAttributes = [
-            NSAttributedString.Key.font: font,
-            NSAttributedString.Key.foregroundColor: color
-        ]
         animationTimeInterval = 1.0 / 30
     }
 
     override func startAnimation() {
         settings = PolyhedraSettings()
-        cachedRenderings = settings.getPolyhedron().generateCachedRenderings(color: settings.fixedColor)
+        if settings.shouldShowPolyhedronName() {
+            let fontSize: CGFloat = isPreview ? 5 : 24
+            // configure text
+            let font = NSFont.systemFont(ofSize: fontSize)
+            let textRect = NSRect(x: fontSize, y: fontSize, width: frame.width, height: fontSize * 1.5)
+            let color = NSColor(calibratedWhite: 1.0, alpha: 0.2)
+            let labelView = NSTextField(frame: textRect)
+            addSubview(labelView)
+            labelView.font = font
+            labelView.isBezeled = false
+            labelView.isSelectable = false
+            labelView.drawsBackground = false
+            labelView.textColor = color
+            labelView.stringValue = settings.getPolyhedron().name
+        }
+        let cachedRenderings = settings.getPolyhedron().generateCachedRenderings(color: settings.fixedColor)
+        polyhedronView = PolyhedronView(origin: position, radius: radius, cachedRenderings: cachedRenderings)
+        addSubview(polyhedronView!)
         super.startAnimation()
     }
 
@@ -60,23 +64,6 @@ class PolyhedraScreenSaverView: ScreenSaverView {
         return sheetController.window
     }
 
-    override func draw(_: NSRect) {
-        // clear the screen
-        NSColor.black.setFill()
-        bounds.fill()
-        if cachedRenderings.isEmpty {
-            // we have not loaded the settings yet
-            return
-        }
-        // fetch a cached rendering
-        let cachedRendering = cachedRenderings[rotation]
-        cachedRendering.render(position: position, radius: radius, lineWidth: 1)
-        // draw polyhedron name
-        if settings.shouldShowPolyhedronName() {
-            settings.getPolyhedron().name.draw(in: textRect, withAttributes: textAttributes)
-        }
-    }
-
     override func animateOneFrame() {
         super.animateOneFrame()
         // update object position
@@ -90,8 +77,33 @@ class PolyhedraScreenSaverView: ScreenSaverView {
         if positionY < 0 || positionY > maxY {
             velocity.dy *= -1
         }
-        // update object rotation
+        polyhedronView!.setFrameOrigin(position)
+        polyhedronView!.rotate()
+    }
+}
+
+class PolyhedronView: NSView {
+    private var radius: CGFloat = .zero
+    private var rotation: Int = .zero
+    private var cachedRenderings: [CachedRendering] = []
+
+    public init(origin: NSPoint, radius: CGFloat, cachedRenderings: [CachedRendering]) {
+        super.init(frame: NSRect(origin: origin, size: NSSize(width: 2 * radius, height: 2 * radius)))
+        self.radius = radius
+        self.cachedRenderings = cachedRenderings
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func rotate() {
         rotation = (rotation + 1) % cachedRenderings.count
         needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        cachedRenderings[rotation].render(position: .zero, radius: radius, lineWidth: 1)
     }
 }

--- a/Polyhedra/PolyhedraScreenSaverView.swift
+++ b/Polyhedra/PolyhedraScreenSaverView.swift
@@ -81,29 +81,3 @@ class PolyhedraScreenSaverView: ScreenSaverView {
         polyhedronView!.rotate()
     }
 }
-
-class PolyhedronView: NSView {
-    private var radius: CGFloat = .zero
-    private var rotation: Int = .zero
-    private var cachedRenderings: [CachedRendering] = []
-
-    public init(origin: NSPoint, radius: CGFloat, cachedRenderings: [CachedRendering]) {
-        super.init(frame: NSRect(origin: origin, size: NSSize(width: 2 * radius, height: 2 * radius)))
-        self.radius = radius
-        self.cachedRenderings = cachedRenderings
-    }
-
-    @available(*, unavailable)
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func rotate() {
-        rotation = (rotation + 1) % cachedRenderings.count
-        needsDisplay = true
-    }
-
-    override func draw(_ dirtyRect: NSRect) {
-        cachedRenderings[rotation].render(position: .zero, radius: radius, lineWidth: 1)
-    }
-}

--- a/Polyhedra/PolyhedraScreenSaverView.swift
+++ b/Polyhedra/PolyhedraScreenSaverView.swift
@@ -14,10 +14,10 @@ class PolyhedraScreenSaverView: ScreenSaverView {
         super.init(frame: frame, isPreview: isPreview)
         if isPreview {
             radius = 25
-            velocity = CGVector(dx: 7, dy: 7)
+            velocity = CGVector(dx: 6, dy: 6)
         } else {
             radius = 150
-            velocity = CGVector(dx: 15, dy: 15)
+            velocity = CGVector(dx: 12, dy: 12)
         }
         // make sure polyhedron (2 * radius in width) does not got off screen
         maxX = frame.width - 2 * radius
@@ -25,7 +25,7 @@ class PolyhedraScreenSaverView: ScreenSaverView {
         // place at a random point in the frame
         position.x = CGFloat.random(in: 0 ..< maxX)
         position.y = CGFloat.random(in: 0 ..< maxY)
-        animationTimeInterval = 1.0 / 20
+        animationTimeInterval = 1.0 / 25
     }
 
     override func startAnimation() {

--- a/Polyhedra/PolyhedraScreenSaverView.swift
+++ b/Polyhedra/PolyhedraScreenSaverView.swift
@@ -14,10 +14,10 @@ class PolyhedraScreenSaverView: ScreenSaverView {
         super.init(frame: frame, isPreview: isPreview)
         if isPreview {
             radius = 25
-            velocity = CGVector(dx: 5, dy: 5)
+            velocity = CGVector(dx: 7, dy: 7)
         } else {
             radius = 150
-            velocity = CGVector(dx: 10, dy: 10)
+            velocity = CGVector(dx: 15, dy: 15)
         }
         // make sure polyhedron (2 * radius in width) does not got off screen
         maxX = frame.width - 2 * radius
@@ -25,7 +25,7 @@ class PolyhedraScreenSaverView: ScreenSaverView {
         // place at a random point in the frame
         position.x = CGFloat.random(in: 0 ..< maxX)
         position.y = CGFloat.random(in: 0 ..< maxY)
-        animationTimeInterval = 1.0 / 30
+        animationTimeInterval = 1.0 / 20
     }
 
     override func startAnimation() {

--- a/Polyhedra/PolyhedronView.swift
+++ b/Polyhedra/PolyhedronView.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+class PolyhedronView: NSView {
+    private var radius: CGFloat = .zero
+    private var rotation: Int = .zero
+    private var cachedRenderings: [CachedRendering] = []
+
+    public init(origin: NSPoint, radius: CGFloat, cachedRenderings: [CachedRendering]) {
+        super.init(frame: NSRect(origin: origin, size: NSSize(width: 2 * radius, height: 2 * radius)))
+        self.radius = radius
+        self.cachedRenderings = cachedRenderings
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func rotate() {
+        rotation = (rotation + 1) % cachedRenderings.count
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        cachedRenderings[rotation].render(position: .zero, radius: radius, lineWidth: 1)
+    }
+}


### PR DESCRIPTION
* use subviews for label and polyhedron.
* do drawing only in subview and have system graphics take care of the rest
* this should cause the display engine to do partial redraws
* the frame fill of black probably ruined a lot of performance, but this is now removed
* lowered from 30 to 25 fps for a little more savings without sacrificing quality.

before:
![image](https://user-images.githubusercontent.com/1082334/145687571-dbb89839-1bcc-4901-9f18-949b2bf434d7.png)

after:
![image](https://user-images.githubusercontent.com/1082334/145687580-6381f24d-f89c-4a75-b11b-060a009e94cd.png)
